### PR TITLE
update image tag to include .jpeg extension

### DIFF
--- a/app/views/boats/index.html.erb
+++ b/app/views/boats/index.html.erb
@@ -7,7 +7,7 @@
   <div class="cards">
     <% @boats.each do |boat| %>
       <div class="card-product">
-        <%= image_tag("boat") %>
+        <%= image_tag("boat.jpg") %>
         <div class="card-product-infos">
           <h2><%= boat.name %></h2>
           <p><%= boat.description %></p>


### PR DESCRIPTION
<img width="1599" alt="CleanShot 2022-06-23 at 21 01 17@2x" src="https://user-images.githubusercontent.com/39948231/175284162-b64de5eb-ded8-4f08-b1b5-28c21ffb322a.png">
Heroku app breaks when loading image tag and boat picture. Fixing issue with image tag not working without .jpeg extension.