### PR TITLE
Updated red browse and dashboard  buttons to match new blue color scheme

### DIFF
--- a/app/views/boats/index.html.erb
+++ b/app/views/boats/index.html.erb
@@ -4,7 +4,7 @@
       <h1>Browse Boats</h1>
       <%= form_with url: "/boats", method: :get do |f| %>
         <%= f.text_field :query, style: "height: 36.2px; width: 300px; padding: 6px 12px;" %>
-        <%= f.submit "Search", class: "btn btn-danger text-white", style: "background-color: rgba(222, 69, 51, 1); border-radius: 5px"%>
+        <%= f.submit "Search", class: "btn btn-primary"%>
         <%= link_to "Reset", boats_path, class: "btn btn-secondary", style: "border-radius: 5px"%>
       <% end %>
     </div>

--- a/app/views/shared/_boat_card.html.erb
+++ b/app/views/shared/_boat_card.html.erb
@@ -11,7 +11,7 @@
         <p><%= boat.description %></p>
         <div class="d-flex justify-content-between pt-3">
           <p>$<%= boat.price %>/day</p>
-          <%= link_to "Details", boat_path(boat), class: "btn btn-outline-danger" %>
+          <%= link_to "Details", boat_path(boat), class: "btn btn-outline-primary" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<img width="1552" alt="CleanShot 2022-06-30 at 18 59 00@2x" src="https://user-images.githubusercontent.com/39948231/176637097-5af347b9-c578-431c-91ee-25961e042e9d.png">
<img width="1552" alt="CleanShot 2022-06-30 at 19 00 06@2x" src="https://user-images.githubusercontent.com/39948231/176637136-462a9d0c-9cfc-4251-971c-47dd1e64f5f4.png">

Kept green and red for actions: 

<img width="1552" alt="CleanShot 2022-06-30 at 19 00 21@2x" src="https://user-images.githubusercontent.com/39948231/176637235-08dff029-453e-4ce1-9957-dd8ebe58a79c.png">

